### PR TITLE
feat: Add missing @types/react dependency

### DIFF
--- a/voter-unions/expo.log
+++ b/voter-unions/expo.log
@@ -1,0 +1,1 @@
+Starting project at /app/voter-unions

--- a/voter-unions/package-lock.json
+++ b/voter-unions/package-lock.json
@@ -29,6 +29,7 @@
         "zustand": "^5.0.8"
       },
       "devDependencies": {
+        "@types/react": "^18.0.0",
         "typescript": "~5.9.2"
       }
     },
@@ -3023,6 +3024,24 @@
       "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
       "license": "MIT"
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.25",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.25.tgz",
+      "integrity": "sha512-oSVZmGtDPmRZtVDqvdKUi/qgCsWp5IDY29wp8na8Bj4B3cc99hfNzvNhlMkVVxctkAOGUA3Km7MMpBHAnWfcIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
+      }
+    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
@@ -4097,6 +4116,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",

--- a/voter-unions/package.json
+++ b/voter-unions/package.json
@@ -30,6 +30,7 @@
     "zustand": "^5.0.8"
   },
   "devDependencies": {
+    "@types/react": "^18.0.0",
     "typescript": "~5.9.2"
   },
   "private": true


### PR DESCRIPTION
Resolves an issue where the project would fail to start due to a missing dependency for React TypeScript definitions.

This change adds `@types/react` to the `devDependencies` in `package.json` to provide the necessary type information for the TypeScript compiler.