### PR TITLE
fix: Move @types/react to dependencies

### DIFF
--- a/voter-unions/package-lock.json
+++ b/voter-unions/package-lock.json
@@ -15,6 +15,7 @@
         "@supabase/supabase-js": "^2.58.0",
         "@tanstack/react-query": "^5.90.2",
         "@tanstack/react-query-persist-client": "^5.90.2",
+        "@types/react": "^18.0.0",
         "expo": "~54.0.12",
         "expo-constants": "^18.0.9",
         "expo-haptics": "^15.0.7",
@@ -29,7 +30,6 @@
         "zustand": "^5.0.8"
       },
       "devDependencies": {
-        "@types/react": "^18.0.0",
         "typescript": "~5.9.2"
       }
     },
@@ -3028,14 +3028,12 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.25",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.25.tgz",
       "integrity": "sha512-oSVZmGtDPmRZtVDqvdKUi/qgCsWp5IDY29wp8na8Bj4B3cc99hfNzvNhlMkVVxctkAOGUA3Km7MMpBHAnWfcIA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -4121,7 +4119,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {

--- a/voter-unions/package.json
+++ b/voter-unions/package.json
@@ -16,6 +16,7 @@
     "@supabase/supabase-js": "^2.58.0",
     "@tanstack/react-query": "^5.90.2",
     "@tanstack/react-query-persist-client": "^5.90.2",
+    "@types/react": "^18.0.0",
     "expo": "~54.0.12",
     "expo-constants": "^18.0.9",
     "expo-haptics": "^15.0.7",
@@ -30,7 +31,6 @@
     "zustand": "^5.0.8"
   },
   "devDependencies": {
-    "@types/react": "^18.0.0",
     "typescript": "~5.9.2"
   },
   "private": true


### PR DESCRIPTION
Moves the `@types/react` package from `devDependencies` to `dependencies`.

This change is necessary to resolve a persistent dependency resolution issue in sandboxed environments like Expo Snack, where `devDependencies` may not be installed correctly by the `snackager` tool. Placing `@types/react` in the main dependencies list ensures it is available to the environment, allowing the project to build and run successfully.